### PR TITLE
Attempted fix for 'site not found'

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.deep-epigenetics.org


### PR DESCRIPTION
I compared the built artifacts from the Github actions and it looks like updating the custom domain in GitHub adds this CNAME file, but when the site is deployed again (via gh-deploy) the CNAME file isn't created and the site becomes unreachable.

It's a guess but worth a try!

After this is merged please pull and redeploy the site to confirm.